### PR TITLE
Scope MAX_POSITIONS constant to class

### DIFF
--- a/lib/a_b_split/functions/weighted_split.rb
+++ b/lib/a_b_split/functions/weighted_split.rb
@@ -60,7 +60,7 @@ module ABSplit
 
         def markers(experiments)
           experiments.map do |experiment| 
-            (MAX_POSITIONS * (experiment['weight'] / 100)) - ( MAX_POSITIONS / 2)
+            (self::MAX_POSITIONS * (experiment['weight'] / 100)) - (self::MAX_POSITIONS / 2)
           end
         end
       end


### PR DESCRIPTION
:information_desk_person: This change scopes the `MAX_POSITIONS` constant to the class itself, which stops Ruby warnings being generated for attempts to re-initialise the constant.
