### PR TITLE
Bump patch version to 0.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: ruby
 cache: bundler
 rvm:
-  - 2.1.1
+  - 2.2.2
+  - 2.1.5
   - 2.0.0
   - 1.9.3

--- a/a_b_split.gemspec
+++ b/a_b_split.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name           = 'a_b_split'
-  s.version        = '0.1.0'
+  s.version        = '0.1.1'
   s.date           = "#{Time.now.strftime("%Y-%m-%d")}"
   s.summary        = 'ABSplit'
   s.license        = 'MIT'

--- a/a_b_split.gemspec
+++ b/a_b_split.gemspec
@@ -2,9 +2,8 @@ Gem::Specification.new do |s|
   s.name           = 'a_b_split'
   s.version        = '0.1.1'
   s.date           = "#{Time.now.strftime("%Y-%m-%d")}"
-  s.summary        = 'ABSplit'
+  s.summary        = 'Splits experiment cohorts for A/B testing'
   s.license        = 'MIT'
-  s.description    = 'A/B split testing gem'
   s.authors        = ['Enrique Figuerola']
   s.email          = 'hard_rock15@msn.com'
   s.files          = Dir.glob('lib/**/*')


### PR DESCRIPTION
:information_desk_person: Bumps the patch version component to 0.1.1. Also updates the (required) summary to be more meaningful and removes the (unrequired) description attribute.